### PR TITLE
v0.2.3

### DIFF
--- a/Application.Database/Application.Database.sqlproj
+++ b/Application.Database/Application.Database.sqlproj
@@ -232,6 +232,7 @@
     <Build Include="FLOWBYTE_DIM.sql" />
     <Build Include="FLOWBYTE_TRANS.sql" />
     <Build Include="FLOWBYTE_RT.sql" />
+    <Build Include="FLOWBYTE_SALES.sql" />
   </ItemGroup>
   <ItemGroup>
     <RefactorLog Include="Application.Database.refactorlog" />

--- a/Application.Database/FLOWBYTE_SALES.sql
+++ b/Application.Database/FLOWBYTE_SALES.sql
@@ -1,0 +1,7 @@
+﻿/*
+Do not change the database path or name variables.
+Any sqlcmd variables will be properly substituted during 
+build and deployment.
+*/
+ALTER DATABASE [$(DatabaseName)]
+	ADD FILEGROUP [FLOWBYTE_SALES]

--- a/Application.Database/dbo/Tables/sales.sql
+++ b/Application.Database/dbo/Tables/sales.sql
@@ -23,4 +23,4 @@
     CONSTRAINT [FK_sales_company_id_item_no] FOREIGN KEY ([company_id],[item_no]) REFERENCES [item]([company_id],[item_no]), 
        
 )
-ON [FLOWBYTE_TRANS];
+ON [FLOWBYTE_SALES];

--- a/Application.Database/dbo/Tables/sales_forecast_by_group.sql
+++ b/Application.Database/dbo/Tables/sales_forecast_by_group.sql
@@ -7,10 +7,10 @@
     [net_amount_acy_lower] DECIMAL(38, 20) NOT NULL, 
     CONSTRAINT [PK_sales_forecast_by_group] PRIMARY KEY NONCLUSTERED ([date], [store_group]) 
 )
-ON [FLOWBYTE_TRANS];
+ON [FLOWBYTE_SALES];
 
 GO
 
 CREATE CLUSTERED INDEX [IX_sales_forecast_by_group_Column] ON [dbo].[sales_forecast_by_group] ([date]) 
-ON [FLOWBYTE_TRANS];
+ON [FLOWBYTE_SALES];
 

--- a/Application.Database/dbo/Tables/sales_forecast_by_group_components.sql
+++ b/Application.Database/dbo/Tables/sales_forecast_by_group_components.sql
@@ -18,9 +18,9 @@
     [specific_regressors] NVARCHAR(MAX) NULL, 
     CONSTRAINT [PK_sales_forecast_by_group_components] PRIMARY KEY NONCLUSTERED ([date], [store_group], [model])
 )
-ON [FLOWBYTE_TRANS];
+ON [FLOWBYTE_SALES];
 
 GO
 
 CREATE CLUSTERED INDEX [IX_sales_forecast_by_group_components_Column] ON [dbo].[sales_forecast_by_group_components] ([date])
-ON [FLOWBYTE_TRANS];
+ON [FLOWBYTE_SALES];

--- a/Application.Database/dbo/Tables/sales_price.sql
+++ b/Application.Database/dbo/Tables/sales_price.sql
@@ -12,12 +12,12 @@
     CONSTRAINT [FK_sales_price_item] FOREIGN KEY ([company_id],[item_no]) REFERENCES [item]([company_id],[item_no]), 
     CONSTRAINT [FK_sales_price_currency] FOREIGN KEY ([currency_code]) REFERENCES [currency]([code]), 
 )
-ON [FLOWBYTE_TRANS];
+ON [FLOWBYTE_SALES];
 
 GO
 
 CREATE INDEX [IX_sales_price_company_id_item_no] ON [dbo].[sales_price] ([company_id],[item_no])
-ON [FLOWBYTE_TRANS];
+ON [FLOWBYTE_SALES];
 
 GO
 


### PR DESCRIPTION
This pull request introduces a new filegroup `FLOWBYTE_SALES` and updates several tables to use this new filegroup instead of `FLOWBYTE_TRANS`. The key changes include the addition of the new filegroup in the project file and the modification of existing tables to use the new filegroup.

Changes to filegroups:

* [`Application.Database/Application.Database.sqlproj`](diffhunk://#diff-2dcee49040875a83d3450c0379e4984e1aa10073dce8f0389169da7cd2eb6dc0R235): Added `FLOWBYTE_SALES.sql` to the build configuration.
* [`Application.Database/FLOWBYTE_SALES.sql`](diffhunk://#diff-be9976d8b278ed968b13990609fd23e43c4abc3237a6add7a6c369a150e808abR1-R7): Created the `FLOWBYTE_SALES` filegroup.

Updates to tables:

* [`Application.Database/dbo/Tables/sales.sql`](diffhunk://#diff-425b7b92a8d057cecf7b248df0912b867932d131786fc4708a54fd2e71c6d557L26-R26): Changed the filegroup for the `sales` table to `FLOWBYTE_SALES`.
* [`Application.Database/dbo/Tables/sales_forecast_by_group.sql`](diffhunk://#diff-4f9ef309aa7141596097cfd58795a2344fb169b49b4d15c583e64034c4f2e6a4L10-R15): Updated the filegroup for the `sales_forecast_by_group` table and its clustered index to `FLOWBYTE_SALES`.
* [`Application.Database/dbo/Tables/sales_forecast_by_group_components.sql`](diffhunk://#diff-a0985b98b94963682f55758012aba1679a4a13c80f003e3668a38ec17e407608L21-R26): Modified the filegroup for the `sales_forecast_by_group_components` table and its clustered index to `FLOWBYTE_SALES`.
* [`Application.Database/dbo/Tables/sales_price.sql`](diffhunk://#diff-a3340db028fe2abfe6665b5e2ba1a843e4ec394dc3346b8cd70ae7a6bd10aa27L15-R20): Updated the filegroup for the `sales_price` table and its index to `FLOWBYTE_SALES`.